### PR TITLE
Fix Debian support and update h2o and dependencies

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,2 @@
-source 'https://api.berkshelf.com'
-
+source 'https://supermarket.chef.io'
 metadata
-
-cookbook 'build-essential', git: 'https://github.com/chef-cookbooks/build-essential.git'
-cookbook 'cmake', git: 'https://github.com/phlipper/chef-cmake.git'

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,17 +1,16 @@
 DEPENDENCIES
-  build-essential
-    git: https://github.com/chef-cookbooks/build-essential.git
-    revision: 35174d52fe64f1203eceb79a93228a25f17119ad
-  cmake
-    git: https://github.com/phlipper/chef-cmake.git
-    revision: 85eba99819c4a938711cc5f6e809dc8159495488
   h2o
     path: .
     metadata: true
 
 GRAPH
-  build-essential (2.2.4)
-  cmake (0.3.0)
-  h2o (0.1.0)
+  build-essential (8.1.1)
+    mingw (>= 1.1)
+    seven_zip (>= 0.0.0)
+  h2o (1.0.0)
     build-essential (>= 0.0.0)
-    cmake (>= 0.0.0)
+  mingw (2.0.2)
+    seven_zip (>= 0.0.0)
+  seven_zip (3.0.0)
+    windows (>= 0.0.0)
+  windows (4.2.5)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,10 +3,13 @@
 
 default['h2o']['build'] = false
 
-default['h2o']['version'], default['h2o']['pid'], default['h2o']['user'], default['h2o']['group'], default['h2o']['bin'] = if node['h2o']['build']
-    %w(1.5.4 /var/run/h2o.pid h2o h2o /usr/local/bin)
+default['h2o']['pid'], \
+default['h2o']['user'], \
+default['h2o']['group'], \
+default['h2o']['bin'] = if node['h2o']['build']
+    %w(/var/run/h2o.pid h2o h2o /usr/local/bin)
   else
-    %w(1.2.0-20.1 /var/run/h2o/h2o.pid nobody nogroup /usr/sbin)
+    %w(/var/run/h2o/h2o.pid nobody nogroup /usr/sbin)
   end
 
 default['h2o']['pkg_platform'] = case node['platform']
@@ -42,7 +45,9 @@ when 'debian'
 end
 
 # source
-default['h2o']['download_url']       = "https://github.com/h2o/h2o/archive/v#{node['h2o']['version']}.zip"
+default['h2o']['download_version']   = '2.2.5'
+default['h2o']['download_url']       = "https://github.com/h2o/h2o/archive/v#{node['h2o']['download_version']}.zip"
+default['h2o']['download_checksum']  = '1fbd2e06c2d3d9d8e844d64439513b1947684e0c09a65ddaa9e77a2af77791c0'
 default['h2o']['dir']                = '/etc/h2o'
 default['h2o']['init_cookbook']      = 'h2o'
 default['h2o']['logrotate_cookbook'] = 'h2o'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,13 +4,12 @@ maintainer_email 'linyows@gmail.com'
 license          'MIT'
 description      'Installs/Configures h2o'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '1.0.0'
 
 depends 'build-essential'
-depends 'cmake'
 recipe 'h2o', 'Installs and configures h2o'
 %w(centos redhat fedora ubuntu debian).each { |os| supports os }
 
 source_url 'https://github.com/linyows/h2o-cookbook'
 issues_url 'https://github.com/linyows/h2o-cookbook/issues'
-chef_version '>= 12.9' if respond_to?(:chef_version)
+chef_version '>= 13'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -2,7 +2,8 @@
 # Recipe:: config
 
 if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 7 ||
-   node['platform_family'] == 'debian' && node['platform_version'].to_i >= 16
+   node['platform'] == 'ubuntu' && node['platform_version'].to_i >= 16 ||
+   node['platform_family'] == 'debian'
   execute 'systemctl daemon-reload for h2o' do
     command 'systemctl daemon-reload'
     action :nothing

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,10 +20,7 @@ else
     comment 'Service user for h2o'
   end if node['h2o']['user'] != 'nobody'
 
-  package 'h2o' do
-    version node['h2o']['version']
-    action :install
-  end
+  package 'h2o'
 end
 
 include_recipe 'h2o::html' if node['h2o']['default_html']

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -10,11 +10,12 @@ when 'debian'
   package %w[curl unzip cmake pkg-config libssl-dev zlib1g-dev]
 end
 
-version = node['h2o']['version']
+version = node['h2o']['download_version']
 cache_path = Chef::Config[:file_cache_path]
 
 remote_file "#{cache_path}/h2o-#{version}.zip" do
   source node['h2o']['download_url']
+  checksum node['h2o']['download_checksum']
   action :create_if_missing
 end
 

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -1,15 +1,14 @@
 # Cookbook Name:: h2o
 # Recipe:: source
 
-include_recipe 'build-essential'
-include_recipe 'cmake::_source'
+build_essential 'install_build_packages'
 
-%w(
-  curl
-  unzip
-  libyaml-devel
-  openssl-devel
-).each { |name| package name }
+case node['platform_family']
+when 'rhel', 'fedora'
+  package %w[curl unzip cmake openssl-devel libyaml-devel]
+when 'debian'
+  package %w[curl unzip cmake pkg-config libssl-dev zlib1g-dev]
+end
 
 version = node['h2o']['version']
 cache_path = Chef::Config[:file_cache_path]
@@ -30,7 +29,7 @@ end
 bash "install h2o-#{version}" do
   code <<-CODE
     cd #{cache_path}/h2o-#{version}
-    /usr/local/bin/cmake -DWITH_BUNDLED_SSL=on .
+    cmake -DWITH_BUNDLED_SSL=on .
     make && make install
   CODE
   not_if "/usr/local/bin/h2o -v 2>&1 | grep -q #{version}"


### PR DESCRIPTION
Thank you for making this cookbook. I made a bunch of little changes:

- fixed dependencies for Debian
- updated dependent cookbooks
- updated h2o version
- added checksum for source zipfile
- require Chef 13+ (Chef 12 is EOL'd)
- bumped version to 1.0.0 to respect semver

Let me know if you want me to tweak anything before merging.