### PR TITLE
add ExecStartPre to service file

### DIFF
--- a/templates/default/h2o.service.erb
+++ b/templates/default/h2o.service.erb
@@ -6,6 +6,7 @@ After=network.target remote-fs.target nss-lookup.target
 [Service]
 Type=simple
 PIDFile=<%= node['h2o']['pid'] %>
+ExecStartPre=<%= node['h2o']['bin'] %>/h2o -m master -c <%= node['h2o']['dir'] %>/h2o.conf -t
 ExecStart=<%= node['h2o']['bin'] %>/h2o -m master -c <%= node['h2o']['dir'] %>/h2o.conf
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s QUIT $MAINPID


### PR DESCRIPTION
`systemctl start h2o` returns 0 even though failed to start server.
i changed to run h2o test (`--test` option) before start.